### PR TITLE
Support for newer librosa versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ hydra_core==1.0.3
 hydra_colorlog==1.0.0
 pystoi==0.3.3
 torchaudio==0.6.0
-librosa==0.7.1
+librosa==0.9.2
 numba==0.48

--- a/svoice/separate.py
+++ b/svoice/separate.py
@@ -11,7 +11,7 @@ import logging
 import os
 import sys
 
-import librosa
+import soundfile as sf
 import torch
 import tqdm
 
@@ -55,7 +55,7 @@ def save_wavs(estimate_source, mix_sig, lengths, filenames, out_dir, sr=16000):
 
 
 def write(inputs, filename, sr=8000):
-    librosa.output.write_wav(filename, inputs, sr, norm=True)
+    sf.write(filename, inputs, sr, subtype='PCM_24')
 
 
 def get_mix_paths(args):


### PR DESCRIPTION
Librosa dropped support for "write_wav" method from 0.8.0.

As they say [on their official documentation](https://librosa.org/doc/0.9.2/ioformats.html#write-out-audio-files), the new method of exporting wav files is to use soundfile directly.

This commit allows to use newer versions of librosa. I listed 0.9.2 on requirements.txt, but 0.10.0 should work fine as well
